### PR TITLE
redirect ingress til ny side

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -38,7 +38,7 @@ jobs:
 
     deploy-to-dev-gcp:
         name: Deploy to dev-gcp
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/redirect-til-ny-side'
         needs: compile-test-and-build
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/deploy-redirect-dev.yaml
+++ b/.github/workflows/deploy-redirect-dev.yaml
@@ -1,0 +1,22 @@
+name: Deploy redirect ingress to dev
+run-name: Deploy ingress to dev | ${{ github.event.head_commit.message }}
+on:
+  push:
+    branches:
+      - '**'
+      - '!main'
+    paths:
+      - 'nais/redirect-dev.yaml'
+      - '.github/workflows/deploy-redirect-dev.yaml'
+jobs:
+  deploy:
+    name: Deploy redirect ingress to dev-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy redirect ingress to dev
+        uses: nais/deploy/actions/deploy@master
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: dev-gcp
+          RESOURCE: nais/redirect-dev.yaml

--- a/.github/workflows/deploy-redirect-dev.yaml
+++ b/.github/workflows/deploy-redirect-dev.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Deploy redirect ingress to dev-gcp
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
       - name: Deploy redirect ingress to dev
         uses: nais/deploy/actions/deploy@master
         env:

--- a/.github/workflows/deploy-redirect-prod.yaml
+++ b/.github/workflows/deploy-redirect-prod.yaml
@@ -1,0 +1,21 @@
+name: Deploy redirect ingress to prod
+run-name: Deploy ingress to prod | ${{ github.event.head_commit.message }}
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'nais/redirect-prod.yaml'
+      - '.github/workflows/deploy-redirect-prod.yaml'
+jobs:
+  deploy:
+    name: Deploy redirect ingress to prod-gcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Deploy redirect ingress to prod
+        uses: nais/deploy/actions/deploy@master
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: nais/redirect-prod.yaml

--- a/nais/redirect-dev.yaml
+++ b/nais/redirect-dev.yaml
@@ -7,9 +7,9 @@ metadata:
     prometheus.io/scrape: "false"
   labels:
     app: forebygge-sykefravaer
-    team: teamia
+    team: arbeidsgiver
   name: dev-redirect-forebygge-sykefravar-to-redusere-sykefravar
-  namespace: teamia
+  namespace: arbeidsgiver
 spec:
   ingressClassName: gw-dev-nav-no
   rules:

--- a/nais/redirect-dev.yaml
+++ b/nais/redirect-dev.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: "https://www.nav.no/arbeidsgiver/redusere-sykefravar"
+    prometheus.io/scrape: "false"
+  labels:
+    app: forebygge-sykefravaer
+    team: teamia
+  name: dev-redirect-forebygge-sykefravar-to-redusere-sykefravar
+  namespace: teamia
+spec:
+  ingressClassName: gw-dev-nav-no
+  rules:
+    - host: arbeidsgiver-gcp.dev.nav.no
+      http:
+        paths:
+          - backend:
+              service:
+                name: forebygge-sykefravaer
+                port:
+                  number: 80
+            path: /forebygge-sykefravaer(/|$)(.*)
+            pathType: ImplementationSpecific

--- a/nais/redirect-prod.yaml
+++ b/nais/redirect-prod.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: "https://www.nav.no/arbeidsgiver/redusere-sykefravar"
+    prometheus.io/scrape: "false"
+  labels:
+    app: forebygge-sykefravaer
+    team: arbeidsgiver
+  name: prod-redirect-forebygge-sykefravar-to-redusere-sykefravar
+  namespace: arbeidsgiver
+spec:
+  ingressClassName: gw-nav-no
+  rules:
+    - host: arbeidsgiver.nav.no
+      http:
+        paths:
+          - backend:
+              service:
+                name: forebygge-sykefravaer
+                port:
+                  number: 80
+            path: /forebygge-sykefravaer(/|$)(.*)
+            pathType: ImplementationSpecific


### PR DESCRIPTION
https://arbeidsgiver.nav.no/forebygge-sykefravaer/ har blitt erstattet av https://www.nav.no/arbeidsgiver/redusere-sykefravar

legger til en ingress som redirecter all trafikk fra `arbeidsgiver.nav.no/forebygge-sykefravaer/*` til ny side